### PR TITLE
feat(perf): robustesse du parallélisme et build rapide (v1.0.1)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.openclassrooms</groupId>
 	<artifactId>tourguide</artifactId>
-	<version>1.0.0</version>
+	<version>1.0.1</version>
 	<name>tourguide</name>
 	<description>Demo project for Spring Boot</description>
 	<properties>
@@ -72,7 +72,35 @@
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
 			</plugin>
+			<!-- Build rapide par défaut : exclut les tests de charge (100 000 utilisateurs, ~8 min). -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<configuration>
+					<excludedGroups>performance</excludedGroups>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
+
+	<profiles>
+		<!-- Profil dédié aux tests de charge : ./mvnw test -Pperformance. -->
+		<profile>
+			<id>performance</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-surefire-plugin</artifactId>
+						<!-- Remplace la config de base (sinon l'exclusion du groupe reste active). -->
+						<configuration combine.self="override">
+							<!-- N'exécute que les tests taggés performance. -->
+							<groups>performance</groups>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 
 </project>

--- a/src/main/java/com/openclassrooms/tourguide/service/RewardsService.java
+++ b/src/main/java/com/openclassrooms/tourguide/service/RewardsService.java
@@ -19,7 +19,7 @@ import java.util.List;
  * position visitée, attribue une récompense à l'utilisateur.</p>
  */
 @Service
-public class RewardsService {
+public class RewardsService implements AutoCloseable {
     private static final double STATUTE_MILES_PER_NAUTICAL_MILE = 1.15077945;
 
     // proximity in miles
@@ -36,6 +36,11 @@ public class RewardsService {
      * Délai maximal d'attente de la fin des tâches avant arrêt forcé du pool (minutes).
      */
     private static final long AWAIT_TERMINATION_MINUTES = 20;
+
+    /**
+     * Exécuteur parallèle réutilisable pour le calcul des récompenses de masse.
+     */
+    private final ParallelTaskExecutor executor = new ParallelTaskExecutor(THREAD_POOL_SIZE, AWAIT_TERMINATION_MINUTES);
 
     /**
      * Construit le service avec ses collaborateurs de localisation et de récompenses.
@@ -105,7 +110,18 @@ public class RewardsService {
      * @param users les utilisateurs dont les récompenses sont calculées
      */
     public void calculateRewardsForListUsers(List<User> users) {
-        ParallelTaskExecutor.runInParallel(users, this::calculateRewards, THREAD_POOL_SIZE, AWAIT_TERMINATION_MINUTES);
+        executor.runInParallel(users, this::calculateRewards);
+    }
+
+    /**
+     * Arrête proprement le pool de threads réutilisable du service.
+     *
+     * <p><b>Exemple :</b> appelé par le {@link com.openclassrooms.tourguide.service.TourGuideService}
+     * lors de l'arrêt de l'application pour libérer les threads du calcul de récompenses.</p>
+     */
+    @Override
+    public void close() {
+        executor.close();
     }
 
     /**

--- a/src/main/java/com/openclassrooms/tourguide/service/TourGuideService.java
+++ b/src/main/java/com/openclassrooms/tourguide/service/TourGuideService.java
@@ -55,6 +55,11 @@ public class TourGuideService {
      */
     private static final long AWAIT_TERMINATION_MINUTES = 15;
 
+    /**
+     * Exécuteur parallèle réutilisable pour le suivi de localisation de masse.
+     */
+    private final ParallelTaskExecutor executor = new ParallelTaskExecutor(THREAD_POOL_SIZE, AWAIT_TERMINATION_MINUTES);
+
     /**********************************************************************************
      *
      * Methods Below: For Internal Testing
@@ -196,11 +201,13 @@ public class TourGuideService {
             .toList();
     }
 
-    // Enregistre un hook d'arrêt de la JVM qui stoppe proprement le tracker.
+    // Enregistre un hook d'arrêt de la JVM qui stoppe le tracker et libère les pools de threads.
     private void addShutDownHook() {
         Runtime.getRuntime().addShutdownHook(new Thread() {
             public void run() {
                 tracker.stopTracking();
+                executor.close();
+                rewardsService.close();
             }
         });
     }
@@ -297,7 +304,7 @@ public class TourGuideService {
      * @param users les utilisateurs à localiser
      */
     public void trackListUsersLocations(List<User> users) {
-        ParallelTaskExecutor.runInParallel(users, this::trackUserLocation, THREAD_POOL_SIZE, AWAIT_TERMINATION_MINUTES);
+        executor.runInParallel(users, this::trackUserLocation);
     }
 
 }

--- a/src/main/java/com/openclassrooms/tourguide/util/ParallelTaskExecutor.java
+++ b/src/main/java/com/openclassrooms/tourguide/util/ParallelTaskExecutor.java
@@ -1,61 +1,106 @@
 package com.openclassrooms.tourguide.util;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
 /**
- * Exécute une même action sur chaque élément d'une liste, en parallèle,
- * sur un pool de threads dédié qui est ensuite arrêté proprement.
+ * Exécute une même action sur chaque élément d'une liste, en parallèle, sur un
+ * pool de threads dédié <b>réutilisable</b> détenu par l'instance.
  *
- * <p>Cet utilitaire factorise le motif « pool fixe + {@code runAsync} par
- * élément + attente globale + arrêt » partagé par les traitements de masse
- * (suivi de localisation, calcul de récompenses).</p>
+ * <p>Le pool est créé une seule fois à la construction et réemployé à chaque
+ * appel de {@link #runInParallel(List, Consumer)} : il n'est plus recréé à
+ * chaque cycle de traitement. Les threads sont des <i>daemons</i>, si bien qu'un
+ * pool non fermé ne bloque jamais l'arrêt de la JVM. L'appel à {@link #close()}
+ * arrête proprement le pool.</p>
+ *
+ * <p>Chaque élément est traité en isolation : une exception levée pour un élément
+ * est journalisée puis ignorée, sans interrompre le traitement des autres.</p>
+ *
+ * <p><b>Exemple :</b>
+ * {@code try (var executor = new ParallelTaskExecutor(200, 15)) {
+ * executor.runInParallel(users, this::trackUserLocation); }}</p>
  */
-public final class ParallelTaskExecutor {
+public final class ParallelTaskExecutor implements AutoCloseable {
 
-    // Classe utilitaire : pas d'instanciation.
-    private ParallelTaskExecutor() {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ParallelTaskExecutor.class);
+
+    private final ExecutorService pool;
+    private final long awaitMinutes;
+
+    /**
+     * Crée un exécuteur détenant un pool de threads fixe réutilisable.
+     *
+     * <p><b>Exemple :</b> {@code new ParallelTaskExecutor(200, 15)} crée un pool de
+     * 200 threads daemon, arrêté avec un délai de grâce de 15 minutes.</p>
+     *
+     * @param poolSize     la taille du pool de threads
+     * @param awaitMinutes le délai maximal d'attente (minutes) à la fermeture avant arrêt forcé
+     */
+    public ParallelTaskExecutor(int poolSize, long awaitMinutes) {
+        this.awaitMinutes = awaitMinutes;
+        this.pool = Executors.newFixedThreadPool(poolSize, daemonThreadFactory());
     }
 
     /**
-     * Applique {@code action} à chacun des {@code items} en parallèle, puis
-     * bloque jusqu'à la fin de toutes les tâches avant d'arrêter le pool.
+     * Applique {@code action} à chacun des {@code items} en parallèle, puis bloque
+     * jusqu'à la fin de toutes les tâches. Le pool est conservé pour les appels suivants.
      *
      * <p><b>Exemple :</b>
-     * {@code ParallelTaskExecutor.runInParallel(users, this::trackUserLocation, 200, 15);}</p>
+     * {@code executor.runInParallel(users, this::trackUserLocation);}</p>
      *
-     * @param items        les éléments à traiter (liste éventuellement vide)
-     * @param action       l'action appliquée à chaque élément
-     * @param poolSize      la taille du pool de threads
-     * @param awaitMinutes le délai maximal d'attente (minutes) avant arrêt forcé
-     * @param <T>          le type des éléments traités
+     * @param items  les éléments à traiter (liste éventuellement vide)
+     * @param action l'action appliquée à chaque élément
+     * @param <T>    le type des éléments traités
      */
-    public static <T> void runInParallel(List<T> items, Consumer<T> action, int poolSize, long awaitMinutes) {
-        ExecutorService executor = Executors.newFixedThreadPool(poolSize);
+    public <T> void runInParallel(List<T> items, Consumer<T> action) {
+        CompletableFuture<?>[] futures = items.stream()
+            .map(item -> CompletableFuture.runAsync(() -> appliquerEnIsolant(action, item), pool))
+            .toArray(CompletableFuture[]::new);
+        CompletableFuture.allOf(futures).join();
+    }
+
+    /**
+     * Arrête proprement le pool : attente de la fin des tâches, puis arrêt forcé au-delà du délai.
+     *
+     * <p><b>Exemple :</b> appelé en fin de {@code try-with-resources} ou par le hook d'arrêt
+     * de l'application pour libérer les threads du pool.</p>
+     */
+    @Override
+    public void close() {
+        pool.shutdown();
         try {
-            CompletableFuture<?>[] futures = items.stream()
-                .map(item -> CompletableFuture.runAsync(() -> action.accept(item), executor))
-                .toArray(CompletableFuture[]::new);
-            CompletableFuture.allOf(futures).join();
-        } finally {
-            shutdownAndAwait(executor, awaitMinutes);
+            if (!pool.awaitTermination(awaitMinutes, TimeUnit.MINUTES)) {
+                pool.shutdownNow();
+            }
+        } catch (InterruptedException e) {
+            pool.shutdownNow();
+            Thread.currentThread().interrupt();
         }
     }
 
-    // Arrête proprement le pool : attente de la fin des tâches, puis arrêt forcé au-delà du délai.
-    private static void shutdownAndAwait(ExecutorService executor, long awaitMinutes) {
-        executor.shutdown();
+    // Applique l'action à un élément en isolant son éventuelle erreur du reste du lot.
+    private static <T> void appliquerEnIsolant(Consumer<T> action, T item) {
         try {
-            if (!executor.awaitTermination(awaitMinutes, TimeUnit.MINUTES)) {
-                executor.shutdownNow();
-            }
-        } catch (InterruptedException e) {
-            executor.shutdownNow();
-            Thread.currentThread().interrupt();
+            action.accept(item);
+        } catch (RuntimeException e) {
+            LOGGER.error("Échec du traitement parallèle de l'élément {}", item, e);
         }
+    }
+
+    // Fabrique des threads daemon pour que le pool ne retienne jamais la JVM à l'arrêt.
+    private static ThreadFactory daemonThreadFactory() {
+        return runnable -> {
+            Thread thread = new Thread(runnable);
+            thread.setDaemon(true);
+            return thread;
+        };
     }
 }

--- a/src/test/java/com/openclassrooms/tourguide/TestPerformance.java
+++ b/src/test/java/com/openclassrooms/tourguide/TestPerformance.java
@@ -8,6 +8,7 @@ import gpsUtil.GpsUtil;
 import gpsUtil.location.Attraction;
 import gpsUtil.location.VisitedLocation;
 import org.apache.commons.lang3.time.StopWatch;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -21,6 +22,7 @@ import java.util.concurrent.TimeUnit;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@Tag("performance")
 public class TestPerformance {
 
     private static final int NUMBER_OF_USERS = 100;

--- a/src/test/java/com/openclassrooms/tourguide/util/ParallelTaskExecutorTest.java
+++ b/src/test/java/com/openclassrooms/tourguide/util/ParallelTaskExecutorTest.java
@@ -9,6 +9,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.IntStream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ParallelTaskExecutorTest {
 
@@ -17,7 +19,9 @@ class ParallelTaskExecutorTest {
         List<Integer> items = IntStream.rangeClosed(1, 1000).boxed().toList();
         Set<Integer> traites = ConcurrentHashMap.newKeySet();
 
-        ParallelTaskExecutor.runInParallel(items, traites::add, 50, 1);
+        try (ParallelTaskExecutor executor = new ParallelTaskExecutor(50, 1)) {
+            executor.runInParallel(items, traites::add);
+        }
 
         assertEquals(1000, traites.size());
     }
@@ -26,8 +30,42 @@ class ParallelTaskExecutorTest {
     void runInParallel_listeVide_neFaitRien() {
         AtomicInteger compteur = new AtomicInteger();
 
-        ParallelTaskExecutor.runInParallel(List.<Integer>of(), i -> compteur.incrementAndGet(), 10, 1);
+        try (ParallelTaskExecutor executor = new ParallelTaskExecutor(10, 1)) {
+            executor.runInParallel(List.<Integer>of(), i -> compteur.incrementAndGet());
+        }
 
         assertEquals(0, compteur.get());
+    }
+
+    @Test
+    void runInParallel_uneErreurNInterromptPasLeReste() {
+        List<Integer> items = IntStream.rangeClosed(1, 100).boxed().toList();
+        Set<Integer> traites = ConcurrentHashMap.newKeySet();
+
+        try (ParallelTaskExecutor executor = new ParallelTaskExecutor(10, 1)) {
+            executor.runInParallel(items, i -> {
+                if (i == 50) {
+                    throw new IllegalStateException("échec simulé pour l'élément 50");
+                }
+                traites.add(i);
+            });
+        }
+
+        assertEquals(99, traites.size());
+        assertFalse(traites.contains(50));
+    }
+
+    @Test
+    void runInParallel_reutiliseLeMemePool_surPlusieursAppels() {
+        List<Integer> items = IntStream.rangeClosed(1, 100).boxed().toList();
+        Set<String> threadsUtilises = ConcurrentHashMap.newKeySet();
+
+        try (ParallelTaskExecutor executor = new ParallelTaskExecutor(4, 1)) {
+            executor.runInParallel(items, i -> threadsUtilises.add(Thread.currentThread().getName()));
+            executor.runInParallel(items, i -> threadsUtilises.add(Thread.currentThread().getName()));
+        }
+
+        // Un pool réutilisé ne mobilise jamais plus de threads que sa taille, même sur deux appels.
+        assertTrue(threadsUtilises.size() <= 4);
     }
 }


### PR DESCRIPTION
Applique trois pistes d'« évolutions futures » de la v1.0.0, **sans refonte**.

## Changements
- **Pool réutilisable** : `ParallelTaskExecutor` devient `AutoCloseable` (pool créé une fois, threads *daemon*), détenu par chaque service et fermé par le hook d'arrêt.
- **Isolation d'erreur** : une exception sur un élément est journalisée puis ignorée, le lot continue (best-effort).
- **`@Tag("performance")` + Surefire** : build rapide par défaut (tests de charge exclus), profil `-Pperformance` pour les rejouer.
- Version portée à **1.0.1**.

## Tests
- Build rapide : 17 tests verts (~5 s).
- Nouveaux tests : isolation d'erreur (99/100) et réutilisation du pool.

Après merge : tag `v1.0.1` pour publier la release.