### PR TITLE
chore: version 1.0.2 (release avec README à jour)

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,4 +153,4 @@ git push origin v1.0.0
 
 ## Version
 
-**1.0.1**
+**1.0.2**

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.openclassrooms</groupId>
 	<artifactId>tourguide</artifactId>
-	<version>1.0.1</version>
+	<version>1.0.2</version>
 	<name>tourguide</name>
 	<description>Demo project for Spring Boot</description>
 	<properties>


### PR DESCRIPTION
Bump de version pour publier une release incluant le README aligné sur `-Pperformance` (la v1.0.1 avait été taguée avant cette doc).